### PR TITLE
copyright for manual.pdf - clarify licence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # gevolution-1.2
 
+## Files: manual.pdf
+
+Copyright (c) 2015-2019 CC-BY-ND Julian Adamek
+(Université de Genève & Observatoire de Paris & Queen Mary University of London)
+
+The file "manual.pdf" is licensed under a Creative Commons
+Attribution-NoDerivatives 4.0 International License - see
+https://creativecommons.org/licenses/by-nd/4.0/ for details.
+
+## All other files:
+
 Copyright (c) 2015-2019 Julian Adamek
 (Université de Genève & Observatoire de Paris & Queen Mary University of London)
 


### PR DESCRIPTION
Hi Julian! :) Based on our recent discussion, it seems that you would
prefer manual.pdf to be licensed under CC-BY-ND rather than the
present permissive licence. It would be best that you clarify this,
which is proposed in this commit/pull request for README.md

Hypothetically, this will not prevent people from converting versions
of manual.pdf in older commits to text and then into LaTeX format
under the previous "permissive" licence, but my prediction is that
nobody will want to do that, and people will prefer to develop
documentation that is clearly free licensed rather than non-free
(CC-BY-ND is non-free in the software licensing sense: it prevents
Derivatives).